### PR TITLE
Fixed variable in character import cron

### DIFF
--- a/wow.class.php
+++ b/wow.class.php
@@ -557,7 +557,7 @@ if(!class_exists('wow')) {
 
 					$char_server	= $this->pdh->get('member', 'profile_field', array($memberID, 'servername'));
 					$servername		= ($char_server != '') ? $char_server : $this->config->get('servername');
-					$chardata		= $this->game->obj['armory']->character($membername, unsanitize($servername), true);
+					$chardata		= $this->game->obj['armory']->character($strMemberName, unsanitize($servername), true);
 
 					if($chardata && !isset($chardata['status']) && !empty($chardata['name']) && $chardata['name'] != 'none'){
 						$errormsg	= '';


### PR DESCRIPTION
This PR fixes a variable in the character import part of the cron job, which, as far as I can tell, prevents the character import part of the cron from working. (It also generates a bunch of PHP warnings in the error logs when the cron job runs.)

As an aside, since the character import is hard-coded to only import one character per request (`maxChardataUpdates`), this cron job will only ever import one character per run (which seems to defeat its purpose). It would be great if there was a way around this (perhaps a cron-specific `maxChardataUpdates` config option?)