### PR TITLE
Added cron option for importing only specific ranks

### DIFF
--- a/wow.class.php
+++ b/wow.class.php
@@ -483,7 +483,7 @@ if(!class_exists('wow')) {
 
 			// Sanitize the 'only import ranks' param, if provided
 			$onlyImportRanks = false;
-			if (!empty($arrParams['char_import_ranks_level'])) {
+			if (!empty($arrParams['char_import_only_ranks'])) {
 				$onlyImportRanks = array();
 				$rawOnlyImportRanks = explode(',');
 

--- a/wow.class.php
+++ b/wow.class.php
@@ -485,7 +485,7 @@ if(!class_exists('wow')) {
 			$onlyImportRanks = false;
 			if (!empty($arrParams['char_import_only_ranks'])) {
 				$onlyImportRanks = array();
-				$rawOnlyImportRanks = explode(',');
+				$rawOnlyImportRanks = explode(',', $arrParams['char_import_only_ranks']);
 
 				foreach ($rank as $rawOnlyImportRanks) {
 					$rank = trim($rank);


### PR DESCRIPTION
This PR adds an "only import these ranks" option to the cronjob. 

Unless I'm missing something, the existing "Import chars with a level higher than X" option is useful if your guild ranks are structured where numerically higher ranks are the ones you want, but not if it's the other way around (e.g. if 0 is Guild Master), or if your ranks are not ordered.

With this option, you can instead input a comma separated list like `2,4,5`, and then only those ranks will be imported. The option is only used if `char_import_ranks_level` is not set.