### PR TITLE
Favour cached data for calendar member tooltips

### DIFF
--- a/wow.class.php
+++ b/wow.class.php
@@ -723,7 +723,7 @@ if(!class_exists('wow')) {
 			$this->game->new_object('bnet_armory', 'armory', array($this->config->get('uc_server_loc'), $this->config->get('uc_data_lang')));
 			$char_server	= $this->pdh->get('member', 'profile_field', array($memberid, 'servername'));
 			$servername		= ($char_server != '') ? $char_server : $this->config->get('servername');
-			$chardata		= $this->game->obj['armory']->character($member_data['name'], unsanitize($servername), true);
+			$chardata		= $this->game->obj['armory']->character($member_data['name'], unsanitize($servername), false);
 			$itemlevel		= (isset($chardata['items']['averageItemLevel'])) ? $chardata['items']['averageItemLevel'] : '--';
 
 			return array(


### PR DESCRIPTION
This PR updates the calendar member tooltips to not "force" a refetch of Armory data. Before, viewing the calendar page would result in at least one Armory request (making the page load quite slowly). After yesterday's change, it is much slower, since "force" char updates are no longer limited to one per request, meaning an Armory request per member.